### PR TITLE
Add JSON output to the client

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -322,6 +322,22 @@ jobs:
       contents: write
 
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Read the changelog section of this release
+      id: changelog
+      run: |
+        {
+          echo 'notes<<CHANGELOG_EOF'
+          awk -v version="${{ needs.determine-version.outputs.version }}" '
+            $0 ~ "^## \\[" version "\\]" { found = 1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md
+          echo 'CHANGELOG_EOF'
+        } >> "$GITHUB_OUTPUT"
+
     - name: Download all binaries
       uses: actions/download-artifact@v4
 
@@ -385,6 +401,9 @@ jobs:
         name: Release v${{ needs.determine-version.outputs.version }}
         body: |
           ## Release v${{ needs.determine-version.outputs.version }}
+
+          ### What is new
+          ${{ steps.changelog.outputs.notes }}
 
           ### Downloads
 

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -40,6 +40,11 @@ jobs:
       run: |
         cargo build --release --target x86_64-unknown-linux-gnu
         echo "Build completed successfully"
+
+    - name: Run unit tests
+      run: |
+        cargo test --lib --target x86_64-unknown-linux-gnu
+        echo "Unit tests completed successfully"
         
     - name: Prepare test environment
       run: |
@@ -225,6 +230,92 @@ jobs:
         
         echo "✅ Client WSS test completed successfully"
         
+    - name: Run nettest client JSON test
+      run: |
+        cd test-run
+
+        echo "Running nettest client test with -json..."
+        echo "Client command: ./nettest -c 127.0.0.1 -json"
+
+        # stdout has to carry the JSON document and nothing else,
+        # so diagnostics are separated into a different file.
+        timeout 60s ./nettest -c 127.0.0.1 -json > result.json 2> result.err
+        CLIENT_EXIT_CODE=$?
+
+        echo "Client exit code: $CLIENT_EXIT_CODE"
+        echo "=== stdout ==="
+        cat result.json
+        echo "=== stderr ==="
+        cat result.err
+
+        if [ $CLIENT_EXIT_CODE -ne 0 ]; then
+          echo "❌ Client JSON test failed"
+          exit 1
+        fi
+
+        if ! python3 -m json.tool result.json > /dev/null; then
+          echo "❌ Output on stdout is not valid JSON"
+          exit 1
+        fi
+
+        python3 - <<'PY'
+        import json
+        import sys
+
+        with open("result.json") as handle:
+            document = json.load(handle)
+
+        def require(condition, message):
+            if not condition:
+                print(f"❌ {message}")
+                sys.exit(1)
+
+        require(document["type"] == "measurement", "unexpected document type")
+        require(document["client"]["name"] == "nettest", "unexpected client name")
+        require(document["server"]["host"] == "127.0.0.1", "unexpected server host")
+        require(document["protocol"] == "tcp", "unexpected protocol")
+        require(document["ping"]["latency_ms"] >= 0, "missing ping latency")
+        require(document["download"]["speed_bps"] > 0, "missing download speed")
+        require(document["upload"]["speed_bps"] > 0, "missing upload speed")
+        require(document["download"]["bytes_transferred"] > 0, "missing download volume")
+        require(document["upload"]["bytes_transferred"] > 0, "missing upload volume")
+
+        print("✅ JSON document contains every expected value")
+        PY
+
+        echo "✅ Client JSON test completed successfully"
+
+    - name: Run nettest client raw test
+      run: |
+        cd test-run
+
+        echo "Running nettest client test with -raw..."
+
+        timeout 60s ./nettest -c 127.0.0.1 -raw > result.raw 2> raw.err
+        CLIENT_EXIT_CODE=$?
+
+        echo "Client exit code: $CLIENT_EXIT_CODE"
+        echo "=== stdout ==="
+        cat result.raw
+
+        if [ $CLIENT_EXIT_CODE -ne 0 ]; then
+          echo "❌ Client raw test failed"
+          exit 1
+        fi
+
+        # The raw format is a single line of three numbers: ping/download/upload.
+        if [ "$(wc -l < result.raw)" -ne 1 ]; then
+          echo "❌ Raw output is not a single line"
+          exit 1
+        fi
+
+        if ! grep -Eq '^[0-9]+\.[0-9]+/[0-9]+\.[0-9]+/[0-9]+\.[0-9]+$' result.raw; then
+          echo "❌ Raw output is not parseable"
+          exit 1
+        fi
+
+        echo "✅ Client raw test completed successfully"
+
     - name: Test completed
       run: |
         echo "✅ All tests completed successfully"

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -3,6 +3,8 @@ name: Test on Main Branch
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
     
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to nettest are recorded in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+nettest follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The release notes of every release contain the section of this file that belongs
+to that version. Releases before 2.1.0 are listed on the
+[releases page](https://github.com/specure/nettest/releases) only.
+
+## [Unreleased]
+
+## [2.1.0] - 2026-08-05
+
+### Added
+
+- The `-json` option. The client writes the measurement to stdout as one JSON
+  document. The document reports the native units of nettest: milliseconds for
+  latency and jitter, bits per second for speed, bytes for the transferred
+  volume and percent for packet loss. A value that nettest did not measure is
+  left out instead of being reported as zero.
+
+### Changed
+
+- The client writes its diagnostics to stderr instead of stdout. In `-raw` mode
+  stdout now holds the single `ping/download/upload` line only.
+
+### Fixed
+
+- The jitter table and the packet loss table no longer appear in `-raw` mode.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "nettest"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nettest"
-version = "2.0.3"
+version = "2.1.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -100,6 +100,69 @@ nettest -c <SERVER_ADDRESS> -ws
 
 # TLS client 
 nettest -c <SERVER_ADDRESS> -tls
+
+# Machine-readable output
+nettest -c <SERVER_ADDRESS> -json
+```
+
+### Output Formats
+
+By default the client prints a table meant for humans. Two flags switch to
+machine-readable output, which keeps stdout free of anything but the result:
+
+| Flag | Output |
+|------|--------|
+| `-raw` | One line: `ping/download/upload`, latency in ms and speed in Gbit/s |
+| `-json` | A JSON document with every measured value |
+
+The JSON document reports nettest's native units: milliseconds for latency and
+jitter, bits per second for speed, percent for packet loss and bytes for the
+transferred volume. A value that was not measured is left out instead of being
+reported as zero, so a consumer can tell "not measured" apart from "measured as
+zero". With `-legacy`, for example, `jitter_ms` and `packet_loss_percent` are
+absent because no VoIP and no UDP test ran.
+
+```console
+$ nettest -c 192.168.1.100 -json
+{
+  "type": "measurement",
+  "timestamp": "2026-08-05T12:34:56Z",
+  "client": {
+    "name": "nettest",
+    "version": "2.1.0"
+  },
+  "server": {
+    "host": "192.168.1.100",
+    "port": 5005
+  },
+  "protocol": "tcp",
+  "num_threads": 3,
+  "failed_threads": 0,
+  "ping": {
+    "latency_ms": 12.34,
+    "jitter_ms": 0.42
+  },
+  "download": {
+    "speed_bps": 942123456,
+    "bytes_transferred": 1177654320
+  },
+  "upload": {
+    "speed_bps": 512345678,
+    "bytes_transferred": 640432098
+  },
+  "packet_loss_percent": 0.0
+}
+```
+
+`jitter_ms` is the mean jitter measured by the VoIP test on an idle line. It is
+not the jitter under download or upload load, because nettest does not measure
+that.
+
+Progress messages, warnings and errors go to stderr in every mode, so piping
+stdout into a parser needs no filtering:
+
+```bash
+nettest -c 192.168.1.100 -json | jq .download.speed_bps
 ```
 
 ## ⚙️ Configuration
@@ -128,6 +191,8 @@ nettest -c <SERVER_ADDRESS> -tls
 | `-t` | Number of threads | `3` |
 | `-p` | TCP/TLS port | `5005` |
 | `-g` | Generate graphs | `false` |
+| `-raw` | Print one parseable line: `ping/download/upload` | `false` |
+| `-json` | Print the measurement as JSON on stdout | `false` |
 | `-legacy` | Use legacy PUT command (skip VoIP/packet loss) | `false` |
 | `-log` | Log level (info, debug, trace) | - |
 

--- a/src/client/api.rs
+++ b/src/client/api.rs
@@ -14,14 +14,41 @@ pub struct MeasurementResult {
     pub download_speed_gbps: f64,
     pub upload_speed_bps: f64,
     pub upload_speed_gbps: f64,
+    /// Total number of bytes received by all threads during the download phase.
+    pub download_bytes: u64,
+    /// Total number of bytes sent by all threads during the upload phase.
+    pub upload_bytes: u64,
     pub jitter_ns: Option<u64>,
     pub packet_loss_percent: Option<f32>,
     pub num_threads: usize,
     pub failed_threads: usize,
 }
 
+/// Sums the transferred bytes of every thread.
+///
+/// Each thread reports cumulative `(timestamp, bytes)` samples, so the last
+/// sample holds the total volume that the thread transferred.
+fn total_bytes(measurements: &[Vec<(u64, u64)>]) -> u64 {
+    measurements
+        .iter()
+        .filter_map(|thread| thread.last().map(|(_, bytes)| *bytes))
+        .sum()
+}
+
 pub async fn run_measurement(config: ClientConfig) -> anyhow::Result<MeasurementResult> {
-    init_max_chunk_size(None);
+    run_measurement_with_chunk_size(config, None).await
+}
+
+/// Runs a measurement while keeping an explicitly configured maximum chunk size.
+///
+/// `run_measurement` falls back to the built-in default, which discards a chunk
+/// size coming from the configuration file. Callers that already parsed a
+/// configuration file pass that value here.
+pub async fn run_measurement_with_chunk_size(
+    config: ClientConfig,
+    max_chunk_size: Option<u32>,
+) -> anyhow::Result<MeasurementResult> {
+    init_max_chunk_size(max_chunk_size);
 
     let thread_count = config.thread_count;
     let stats: Arc<Mutex<SharedStats>> = Arc::new(Mutex::new(SharedStats::default()));
@@ -33,6 +60,8 @@ pub async fn run_measurement(config: ClientConfig) -> anyhow::Result<Measurement
         calculate_download_speed_from_stats_silent(&stats_guard.download_measurements);
     let (ul_bps, ul_gbps, _) =
         calculate_upload_speed_from_stats_silent(&stats_guard.upload_measurements);
+    let download_bytes = total_bytes(&stats_guard.download_measurements);
+    let upload_bytes = total_bytes(&stats_guard.upload_measurements);
     drop(stats_guard);
 
     let failed_threads = thread_count - measurements.len();
@@ -65,6 +94,8 @@ pub async fn run_measurement(config: ClientConfig) -> anyhow::Result<Measurement
         download_speed_gbps: dl_gbps,
         upload_speed_bps: ul_bps,
         upload_speed_gbps: ul_gbps,
+        download_bytes,
+        upload_bytes,
         jitter_ns,
         packet_loss_percent,
         num_threads: thread_count,

--- a/src/client/args_parser.rs
+++ b/src/client/args_parser.rs
@@ -10,6 +10,7 @@ pub async fn parse_args(args: Vec<String>, default_config: FileConfig) -> Result
         use_websocket: default_config.client_use_websocket,
         graphs: false,
         raw_output: false,
+        json_output: false,
         log: None,
         thread_count: default_config.client_thread_count,
         server: None,
@@ -60,6 +61,9 @@ pub async fn parse_args(args: Vec<String>, default_config: FileConfig) -> Result
             }
             "-raw" => {
                 config.raw_output = true;
+            }
+            "-json" => {
+                config.json_output = true;
             }
             "-save" => {
                 config.save_results = true;
@@ -158,6 +162,7 @@ pub fn print_help() {
     println!("    -ws             Use WebSocket protocol");
     println!("    -g              Display download/upload graphs");
     println!("    -raw            Output results in parseable format: ping/download/upload");
+    println!("    -json           Output the measurement as JSON on stdout");
     println!("    -save           Save results to control server");
     println!("    -signed         Request signed result from server");
     println!("    -legacy         Use legacy PUT command instead of PUTTIMERESULT");

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -1,6 +1,8 @@
+use crate::client::api::run_measurement_with_chunk_size;
 use crate::client::args_parser::{parse_args, print_help};
 use crate::client::constants::init_max_chunk_size;
 use crate::client::print::graph_service::GraphService;
+use crate::client::print::json::print_json_result;
 use crate::client::print::printer::print_test_header;
 use crate::client::runnner::run_threads;
 use crate::config::FileConfig;
@@ -45,6 +47,7 @@ pub struct ClientConfig {
     pub use_websocket: bool,
     pub graphs: bool,
     pub raw_output: bool,
+    pub json_output: bool,
     pub thread_count: usize,
     pub log: Option<LevelFilter>,
     pub server: Option<String>,
@@ -67,6 +70,7 @@ impl Default for ClientConfig {
             use_websocket: false,
             graphs: false,
             raw_output: false,
+            json_output: false,
             thread_count: 3,
             log: None,
             server: None,
@@ -89,6 +93,7 @@ pub async fn client_run(args: Vec<String>, dafault_config: FileConfig) -> anyhow
 
     // Initialize MAX_CHUNK_SIZE from config
     init_max_chunk_size(dafault_config.max_chunk_size);
+    let max_chunk_size = dafault_config.max_chunk_size;
 
     if args.contains(&"-h".to_string()) || args.contains(&"--help".to_string()) {
         print_help();
@@ -96,6 +101,12 @@ pub async fn client_run(args: Vec<String>, dafault_config: FileConfig) -> anyhow
     }
 
     let config = parse_args(args, dafault_config).await?;
+
+    if config.json_output {
+        let result = run_measurement_with_chunk_size(config.clone(), max_chunk_size).await?;
+        print_json_result(&result, &config);
+        return Ok(());
+    }
 
     if !config.raw_output {
         print_test_header();

--- a/src/client/print/json.rs
+++ b/src/client/print/json.rs
@@ -1,0 +1,256 @@
+use chrono::{SecondsFormat, Utc};
+use serde::Serialize;
+
+use crate::client::api::MeasurementResult;
+use crate::client::client::ClientConfig;
+
+/// A single nettest measurement in machine-readable form.
+///
+/// The document reports nettest's native units: milliseconds for latency and
+/// jitter, bits per second for speed, percent for packet loss and bytes for the
+/// transferred volume. A value that was not measured is omitted rather than
+/// reported as zero, so a consumer can tell "not measured" apart from "measured
+/// as zero". In `-legacy` mode, for example, jitter and packet loss are absent
+/// because no VoIP and no UDP test ran.
+#[derive(Debug, Serialize)]
+pub struct JsonResult {
+    #[serde(rename = "type")]
+    pub result_type: &'static str,
+    pub timestamp: String,
+    pub client: JsonClient,
+    pub server: JsonServer,
+    pub protocol: &'static str,
+    pub num_threads: usize,
+    pub failed_threads: usize,
+    pub ping: JsonPing,
+    pub download: JsonTransfer,
+    pub upload: JsonTransfer,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub packet_loss_percent: Option<f64>,
+}
+
+/// The client that produced the measurement.
+#[derive(Debug, Serialize)]
+pub struct JsonClient {
+    pub name: &'static str,
+    pub version: &'static str,
+}
+
+/// The measurement server that the client connected to.
+#[derive(Debug, Serialize)]
+pub struct JsonServer {
+    pub host: String,
+    pub port: u16,
+}
+
+/// Latency figures of the ping phase.
+#[derive(Debug, Serialize)]
+pub struct JsonPing {
+    /// Median round trip time in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<f64>,
+    /// Mean jitter in milliseconds, measured by the VoIP test on an idle line.
+    ///
+    /// This is not the jitter under download or upload load; nettest does not
+    /// measure that, so no such value is reported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jitter_ms: Option<f64>,
+}
+
+/// Figures of one transfer direction.
+#[derive(Debug, Serialize)]
+pub struct JsonTransfer {
+    /// Throughput in bits per second, as computed by the RMBT calculation.
+    pub speed_bps: u64,
+    /// Total bytes transferred by all threads in this direction.
+    pub bytes_transferred: u64,
+}
+
+/// Rounds a value to `digits` decimal places.
+fn round(value: f64, digits: u32) -> f64 {
+    let factor = 10_f64.powi(digits as i32);
+    (value * factor).round() / factor
+}
+
+/// Converts nanoseconds to milliseconds, keeping microsecond precision.
+fn ns_to_ms(value: u64) -> f64 {
+    round(value as f64 / 1_000_000.0, 3)
+}
+
+impl JsonResult {
+    pub fn from_measurement(result: &MeasurementResult, config: &ClientConfig) -> Self {
+        Self {
+            result_type: "measurement",
+            timestamp: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+            client: JsonClient {
+                name: "nettest",
+                version: env!("CARGO_PKG_VERSION"),
+            },
+            server: JsonServer {
+                host: config.server.clone().unwrap_or_default(),
+                port: if config.use_tls {
+                    config.tls_port
+                } else {
+                    config.port
+                },
+            },
+            protocol: protocol_name(config),
+            num_threads: result.num_threads,
+            failed_threads: result.failed_threads,
+            ping: JsonPing {
+                latency_ms: result.ping_median_ns.map(ns_to_ms),
+                jitter_ms: result.jitter_ns.map(ns_to_ms),
+            },
+            download: JsonTransfer {
+                speed_bps: result.download_speed_bps.round() as u64,
+                bytes_transferred: result.download_bytes,
+            },
+            upload: JsonTransfer {
+                speed_bps: result.upload_speed_bps.round() as u64,
+                bytes_transferred: result.upload_bytes,
+            },
+            packet_loss_percent: result.packet_loss_percent.map(|loss| round(loss as f64, 2)),
+        }
+    }
+}
+
+/// Names the transport that carried the measurement.
+fn protocol_name(config: &ClientConfig) -> &'static str {
+    match (config.use_websocket, config.use_tls) {
+        (true, true) => "wss",
+        (true, false) => "ws",
+        (false, true) => "tls",
+        (false, false) => "tcp",
+    }
+}
+
+/// Prints the measurement as JSON on stdout.
+///
+/// Nothing else may be written to stdout in JSON mode, so that the output stays
+/// parseable without filtering.
+pub fn print_json_result(result: &MeasurementResult, config: &ClientConfig) {
+    let document = JsonResult::from_measurement(result, config);
+    match serde_json::to_string_pretty(&document) {
+        Ok(json) => println!("{}", json),
+        Err(e) => eprintln!("Failed to serialize the measurement: {}", e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> ClientConfig {
+        ClientConfig {
+            server: Some("192.168.1.100".to_string()),
+            port: 5005,
+            ..Default::default()
+        }
+    }
+
+    fn measurement() -> MeasurementResult {
+        MeasurementResult {
+            ping_median_ns: Some(12_340_000),
+            download_speed_bps: 942_123_456.4,
+            download_speed_gbps: 0.942_123_456,
+            upload_speed_bps: 512_345_678.6,
+            upload_speed_gbps: 0.512_345_678,
+            download_bytes: 1_177_654_320,
+            upload_bytes: 640_432_098,
+            jitter_ns: Some(420_000),
+            packet_loss_percent: Some(0.5),
+            num_threads: 3,
+            failed_threads: 0,
+        }
+    }
+
+    fn to_value(result: &MeasurementResult, config: &ClientConfig) -> serde_json::Value {
+        let document = JsonResult::from_measurement(result, config);
+        serde_json::to_value(&document).unwrap()
+    }
+
+    #[test]
+    fn reports_every_measured_value() {
+        let json = to_value(&measurement(), &config());
+
+        assert_eq!(json["type"], "measurement");
+        assert_eq!(json["client"]["name"], "nettest");
+        assert_eq!(json["client"]["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(json["server"]["host"], "192.168.1.100");
+        assert_eq!(json["server"]["port"], 5005);
+        assert_eq!(json["protocol"], "tcp");
+        assert_eq!(json["num_threads"], 3);
+        assert_eq!(json["failed_threads"], 0);
+        assert!(json["timestamp"].as_str().unwrap().ends_with('Z'));
+    }
+
+    #[test]
+    fn converts_nanoseconds_to_milliseconds() {
+        let json = to_value(&measurement(), &config());
+
+        assert_eq!(json["ping"]["latency_ms"], 12.34);
+        assert_eq!(json["ping"]["jitter_ms"], 0.42);
+    }
+
+    #[test]
+    fn reports_speed_in_bits_per_second_and_volume_in_bytes() {
+        let json = to_value(&measurement(), &config());
+
+        assert_eq!(json["download"]["speed_bps"], 942_123_456u64);
+        assert_eq!(json["download"]["bytes_transferred"], 1_177_654_320u64);
+        assert_eq!(json["upload"]["speed_bps"], 512_345_679u64);
+        assert_eq!(json["upload"]["bytes_transferred"], 640_432_098u64);
+    }
+
+    #[test]
+    fn reports_packet_loss_as_percent() {
+        let json = to_value(&measurement(), &config());
+
+        assert_eq!(json["packet_loss_percent"], 0.5);
+    }
+
+    #[test]
+    fn omits_values_that_were_not_measured() {
+        let mut result = measurement();
+        result.jitter_ns = None;
+        result.packet_loss_percent = None;
+        result.ping_median_ns = None;
+
+        let json = to_value(&result, &config());
+
+        assert!(json.get("packet_loss_percent").is_none());
+        assert!(json["ping"].get("jitter_ms").is_none());
+        assert!(json["ping"].get("latency_ms").is_none());
+    }
+
+    #[test]
+    fn names_the_transport_and_reports_the_port_in_use() {
+        let mut tls = config();
+        tls.use_tls = true;
+        tls.tls_port = 443;
+        let json = to_value(&measurement(), &tls);
+        assert_eq!(json["protocol"], "tls");
+        assert_eq!(json["server"]["port"], 443);
+
+        let mut websocket = config();
+        websocket.use_websocket = true;
+        assert_eq!(to_value(&measurement(), &websocket)["protocol"], "ws");
+
+        let mut secure_websocket = config();
+        secure_websocket.use_websocket = true;
+        secure_websocket.use_tls = true;
+        assert_eq!(
+            to_value(&measurement(), &secure_websocket)["protocol"],
+            "wss"
+        );
+    }
+
+    #[test]
+    fn serializes_to_valid_pretty_json() {
+        let document = JsonResult::from_measurement(&measurement(), &config());
+        let json = serde_json::to_string_pretty(&document).unwrap();
+
+        assert!(json.contains('\n'), "pretty output spans several lines");
+        serde_json::from_str::<serde_json::Value>(&json).unwrap();
+    }
+}

--- a/src/client/print/mod.rs
+++ b/src/client/print/mod.rs
@@ -1,2 +1,3 @@
 pub mod graph_service;
+pub mod json;
 pub mod printer;

--- a/src/client/runnner.rs
+++ b/src/client/runnner.rs
@@ -18,6 +18,23 @@ use crate::client::{
     state::TestState,
 };
 
+/// Prints a measurement row unless the output has to stay machine-readable.
+///
+/// The jitter and packet loss rows are pretty tables. They would corrupt both
+/// the `-raw` line and the `-json` document, so they are skipped in those modes.
+fn print_measurement_row(
+    machine_readable: bool,
+    phase: &str,
+    unit: &str,
+    value: Option<f64>,
+    is_last: bool,
+) {
+    if machine_readable {
+        return;
+    }
+    print_float_result(phase, unit, value, is_last);
+}
+
 pub async fn run_threads(
     config: ClientConfig,
     stats: Arc<Mutex<SharedStats>>,
@@ -75,7 +92,7 @@ pub async fn run_threads(
             match greeting {
                 Ok(_) => {}
                 Err(e) => {
-                    println!("Thread {i} could not connect to the server. {:?}", e);
+                    eprintln!("Thread {i} could not connect to the server. {:?}", e);
                     return Err(anyhow::anyhow!("Greeting failed with error: {:?}", e));
                 }
             }
@@ -93,7 +110,7 @@ pub async fn run_threads(
                 }
                 if config.raw_output {
                     if let Some(p) = ping_ms { print!("{:.2}", p); }
-                } else {
+                } else if !config.json_output {
                     print_float_result("Ping Median", "ms", ping_ms, false);
                 }
 
@@ -108,7 +125,13 @@ pub async fn run_threads(
                             (None,    Some(o)) => Some(o.mean_jitter as f64 / 1_000_000.0),
                             (None,    None)    => None,
                         };
-                        print_float_result("Jitter", "ms", jitter, false);
+                        print_measurement_row(
+                            config.raw_output || config.json_output,
+                            "Jitter",
+                            "ms",
+                            jitter,
+                            false,
+                        );
                     }
 
                     let pre_udp_failed = state.measurement_state().failed;
@@ -127,7 +150,13 @@ pub async fn run_threads(
                         (None,    None)    => None,
                     };
                     if loss.is_some() {
-                        print_float_result("Packet Loss", "%", loss, false);
+                        print_measurement_row(
+                            config.raw_output || config.json_output,
+                            "Packet Loss",
+                            "%",
+                            loss,
+                            false,
+                        );
                     }
                 }
             }
@@ -158,7 +187,7 @@ pub async fn run_threads(
 
                 if config.raw_output {
                     print!("/{:.2}", speed.1); // speed.1 is Gbps
-                } else {
+                } else if !config.json_output {
                     print_test_result("Download Test", "Completed", Some(speed), false);
                 }
             }
@@ -194,7 +223,7 @@ pub async fn run_threads(
 
                 if config.raw_output {
                     println!("/{:.2}", speed.1); // speed.1 is Gbps, println! for line break
-                } else {
+                } else if !config.json_output {
                     print_test_result("Upload Test", "Completed", Some(speed), true);
                 }
             }
@@ -245,7 +274,7 @@ pub async fn run_threads(
         .collect();
 
     if state_refs.len() != config.thread_count {
-        println!("Failed threads: {} out of {}", config.thread_count - state_refs.len(), config.thread_count);
+        eprintln!("Failed threads: {} out of {}", config.thread_count - state_refs.len(), config.thread_count);
     }
 
     let envelopes: Vec<Option<String>> = state_refs.iter().map(|s| s.envelope.clone()).collect();

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -22,11 +22,11 @@ pub fn read_config_file() -> Result<FileConfig, anyhow::Error> {
     let config_content = if config_path.exists() {
         match fs::read_to_string(&config_path) {
             Ok(content) => {
-                println!("Reading config from: {:?}", config_path);
+                eprintln!("Reading config from: {:?}", config_path);
                 content
             }
             Err(e) => {
-                println!(
+                eprintln!(
                     "Warning: Could not read config file {:?}: {}",
                     config_path, e
                 );
@@ -37,19 +37,19 @@ pub fn read_config_file() -> Result<FileConfig, anyhow::Error> {
         if let Some(parent) = config_path.parent() {
             if !parent.exists() {
                 if let Err(e) = fs::create_dir_all(parent) {
-                    println!("Warning: Could not create config directory: {}", e);
+                    eprintln!("Warning: Could not create config directory: {}", e);
                 }
             }
         }
         let default_config = include_str!("../../nettest.conf");
 
         if let Err(e) = fs::write(&config_path, default_config) {
-            println!(
+            eprintln!(
                 "Warning: Could not create config file {:?}: {}",
                 config_path, e
             );
         } else {
-            println!("Created default config file at: {:?}", config_path);
+            eprintln!("Created default config file at: {:?}", config_path);
         }
 
         default_config.to_string()
@@ -126,7 +126,7 @@ fn parse_config_content(content: &str) -> Result<FileConfig, anyhow::Error> {
                     } else if value == "trace" {
                         config.logger = LevelFilter::Trace;
                     } else {
-                        println!("Unknown logger level: {}, using default", value);
+                        eprintln!("Unknown logger level: {}, using default", value);
                         return Err(anyhow::anyhow!("Unknown logger level: {}", value));
                     }
                 }
@@ -168,12 +168,12 @@ fn parse_config_content(content: &str) -> Result<FileConfig, anyhow::Error> {
                     if let Ok(size) = value.parse::<u32>() {
                         config.max_chunk_size = Some(size);
                     } else {
-                        println!("Warning: Invalid max_chunk_size value: {}, using default", value);
+                        eprintln!("Warning: Invalid max_chunk_size value: {}, using default", value);
                     }
                 }
                 _ => {
                     //return error
-                    println!("Warning: Unknown config key: {}", key);
+                    eprintln!("Warning: Unknown config key: {}", key);
                     return Err(anyhow::anyhow!("Unknown config key: {}", key));
                 }
             }


### PR DESCRIPTION
## What this does

The client can write a measurement to stdout as one JSON document with `-json`.

```json
{
  "type": "measurement",
  "timestamp": "2026-08-05T11:29:51Z",
  "client": { "name": "nettest", "version": "2.1.0" },
  "server": { "host": "127.0.0.1", "port": 5005 },
  "protocol": "tcp",
  "num_threads": 3,
  "failed_threads": 0,
  "ping": { "latency_ms": 0.016, "jitter_ms": 0.015 },
  "download": { "speed_bps": 223667260573, "bytes_transferred": 193290305536 },
  "upload": { "speed_bps": 235163425805, "bytes_transferred": 205617364992 },
  "packet_loss_percent": 0.0
}
```

## Why

Tools that collect measurements need a stable interface. The `-raw` line carries
three numbers only, and it loses jitter and packet loss. The first consumer is a
nettest provider for speedtest-tracker.

## Decisions in this change

The document reports the units that nettest measures in: milliseconds, bits per
second, bytes and percent. Nothing is converted to match another client.

A value that nettest did not measure is left out instead of being reported as
zero. A consumer can tell "not measured" apart from "measured as zero". In
`-legacy` mode, for example, jitter and packet loss are absent.

Jitter is reported under `ping` only. The VoIP test measures jitter on an idle
line, so it is a ping figure. Nettest does not measure jitter under load, so no
such value is reported.

The output is pretty printed. A measurement is a few hundred bytes, and a person
who runs the client by hand can read it.

## Side effect on stdout

Diagnostics move from stdout to stderr, so stdout carries the JSON document and
nothing else. This also fixes `-raw`, where the jitter table and the packet loss
table used to break the single parseable line.

## New in the repository

There is a changelog now, and the release notes of a release contain the section
of that version. Until now the notes listed downloads only, so a user could not
see what changed.

## Tests

- 7 unit tests on the JSON module cover the units, the absent values, the
  protocol names and the pretty output.
- CI runs the unit tests, runs the client with `-json` against a local server and
  validates the document, and checks that `-raw` is a single parseable line.